### PR TITLE
Update deployment.yaml so env does not override envFrom

### DIFF
--- a/charts/tooljet/templates/deployment.yaml
+++ b/charts/tooljet/templates/deployment.yaml
@@ -36,8 +36,6 @@ spec:
           env:
             - name: TOOLJET_HOST
               value: "{{ .Values.apps.tooljet.service.host }}"
-            - name: PG_HOST
-              value: "{{ .Release.Name }}-postgresql"
             {{- if .Values.postgresql.existingSecret }}
             - name: POSTGRES_PASSWORD
               valueFrom:


### PR DESCRIPTION
envFrom : List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.