### PR TITLE
Fix for PG_HOST variables

### DIFF
--- a/charts/tooljet/templates/deployment.yaml
+++ b/charts/tooljet/templates/deployment.yaml
@@ -36,8 +36,6 @@ spec:
           env:
             - name: TOOLJET_HOST
               value: "{{ .Values.apps.tooljet.service.host }}"
-            - name: PG_HOST
-              value: "{{ .Release.Name }}-postgresql"
             {{- if .Values.postgresql.existingSecret }}
             - name: POSTGRES_PASSWORD
               valueFrom:


### PR DESCRIPTION
Defined here, it will always have precedence over any variables in the secret below