### PR TITLE
feat: option to disable hpa added

### DIFF
--- a/charts/tooljet/templates/hpa.yaml
+++ b/charts/tooljet/templates/hpa.yaml
@@ -1,3 +1,5 @@
+{{- with .Values.apps.tooljet.hpa }}
+{{- if .enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -7,14 +9,16 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: tooljet
-  minReplicas: {{ .Values.apps.tooljet.hpa.min }}
-  maxReplicas: {{ .Values.apps.tooljet.hpa.max }}
+  minReplicas: {{ .min }}
+  maxReplicas: {{ .max }}
   metrics:
   - type: Resource
     resource:
       name: cpu
-      targetAverageValue: {{ .Values.apps.tooljet.hpa.threshhold.cpu }}
+      targetAverageValue: {{ .threshhold.cpu }}
   - type: Resource
     resource:
       name: memory
-      targetAverageValue: {{ .Values.apps.tooljet.hpa.threshhold.ram }}
+      targetAverageValue: {{ .threshhold.ram }}
+{{- end }}
+{{- end }}

--- a/charts/tooljet/values.yaml
+++ b/charts/tooljet/values.yaml
@@ -15,6 +15,7 @@ apps:
           memory: "2000Mi"
           cpu: "2000m"
     hpa:
+      enabled: true
       min: 1
       max: 1
       threshhold:


### PR DESCRIPTION
### Description of change
Adds an option to disable HPA

### Rationale
For local execution, or clusters that do not have the HPA CRDs. This is especially important for dev environments, and min/slim deployments