### PR TITLE
Disabling enterpise and tooljetdb

### DIFF
--- a/charts/tooljet/values.yaml
+++ b/charts/tooljet/values.yaml
@@ -59,7 +59,7 @@ env:
   DEPLOYMENT_PLATFORM: "k8s:helm"
   db_uri: "postgres://postgres:postgres@tooljet-postgresql.default.svc.cluster.local:5432/tooljet_db"
   jwt_secret: "779ce303294a7d84a2aea9ff1ef1912f9ac57220a0dd2c0861a11ca5ae6c5817"
-  ENABLE_TOOLJET_DB: '"true"'
+  ENABLE_TOOLJET_DB: '"false"'
   TOOLJET_DB_USER: "postgres"
   TOOLJET_DB_HOST: "tooljet-postgresql"
   TOOLJET_DB_PASS: "postgres"
@@ -67,7 +67,7 @@ env:
   PGRST_HOST: "tooljet-postgrest.default.svc.cluster.local"
 
 enterprise:
-  enabled: true
+  enabled: false
   LICENSE_KEY: ""
   REDIS_HOST: "redis-master"
   REDIS_PORT: '"6379"'


### PR DESCRIPTION
set the flag as false for enterpise and tooljetdb, as user's choice to enable it. 