### PR TITLE
Fix for HPA file

### DIFF
--- a/charts/tooljet/templates/hpa.yaml
+++ b/charts/tooljet/templates/hpa.yaml
@@ -1,4 +1,5 @@
-apiVersion: autoscaling/v2beta1
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: tooljet
@@ -14,7 +15,10 @@ spec:
     resource:
       name: cpu
       targetAverageValue: {{ .Values.apps.tooljet.hpa.threshhold.cpu }}
+      targetType: AverageValue
   - type: Resource
     resource:
       name: memory
       targetAverageValue: {{ .Values.apps.tooljet.hpa.threshhold.ram }}
+      targetType: AverageValue      
+{{- end }}


### PR DESCRIPTION
HPA was throwing an error helm.go:84: [debug] resource mapping not found for name: “tooljet” namespace: “” from “”: no matches for kind “HorizontalPodAutoscaler” in version “autoscaling/v2beta1”. 

hence added {{- if .Values.autoscaling.enabled }}