### PR TITLE
Add Ingress Support

### DIFF
--- a/charts/tooljet/Chart.yaml
+++ b/charts/tooljet/Chart.yaml
@@ -16,5 +16,5 @@ dependencies:
   version: "16.13.2"
   repository: "https://charts.bitnami.com/bitnami"  
 
-version: 2.6.0
+version: 2.6.1
 appVersion: "v1.21.5"

--- a/charts/tooljet/templates/_helpers.tpl
+++ b/charts/tooljet/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tooljet.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tooljet.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tooljet.labels" -}}
+helm.sh/chart: {{ include "tooljet.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "tooljet.ingress.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/tooljet/templates/configmap-nginx.yaml
+++ b/charts/tooljet/templates/configmap-nginx.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "tooljet.fullname" . }}-nginx-config-template
+  labels:
+    app: {{ template "tooljet.fullname" . }}
+    chart: {{ template "tooljet.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  nginx.conf.template: "
+  events
+  {
+    worker_connections 1024;
+  }
+  http
+  {
+    server
+    {
+
+      location /
+      {
+        root /var/www;
+        try_files $uri $uri/ /index.html @proxy;
+        error_page 405 @proxy;
+      }
+
+      location /api/
+      {
+        try_files /_bypass_to_proxy @proxy;
+      }
+
+      location /ws
+      {
+        proxy_pass http://{{ template "tooljet.fullname" . }}:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+      }
+
+      location /yjs
+      {
+        proxy_pass http://{{ template "tooljet.fullname" . }}:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+      }
+
+      location @proxy {
+        proxy_pass http://{{ template "tooljet.fullname" . }}:3000;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+      }
+    }
+
+    server
+    {
+      listen 80;
+
+      location /
+      {
+        root /var/www;
+        try_files $uri $uri/ /index.html @proxy;
+        error_page 405 @proxy;
+      }
+
+      location /api/
+      {
+        try_files /_bypass_to_proxy @proxy;
+      }
+
+      location /ws
+      {
+        proxy_pass http://{{ template "tooljet.fullname" . }}:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+      }
+
+      location /yjs
+      {
+        proxy_pass http://{{ template "tooljet.fullname" . }}:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+      }
+
+      location @proxy {
+        proxy_pass http://{{ template "tooljet.fullname" . }}:3000;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+      }
+    }
+
+    server
+    {
+      listen 127.0.0.1:8999;
+      client_body_buffer_size 128k;
+      client_max_body_size 128k;
+    }
+}"

--- a/charts/tooljet/templates/ingress.yml
+++ b/charts/tooljet/templates/ingress.yml
@@ -1,0 +1,55 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "tooljet.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tooljet.fullname" . }}
+  labels:
+    {{- include "tooljet.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  tls:
+    - hosts:
+      - {{ .Values.ingress.hostname }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            pathType: 'Prefix'
+            backend:
+              service:
+                name: {{ template "tooljet.fullname" . }}
+                port:
+                  number: 3000
+  {{- end }}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: 'Prefix'
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 3000
+  {{- end }}
+{{- end }}

--- a/charts/tooljet/templates/service.yaml
+++ b/charts/tooljet/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: tooljet
+  name: {{ template "tooljet.fullname" . }}
 spec:
   type: {{ .Values.apps.tooljet.service.type }}
   ports:

--- a/charts/tooljet/values.yaml
+++ b/charts/tooljet/values.yaml
@@ -36,6 +36,7 @@ ingress:
     {}
   tls: []
 # https://artifacthub.io/packages/helm/bitnami/postgresql#global-parameters
+
 postgresql:
   enabled: true
   postgresqlExtendedConf:

--- a/charts/tooljet/values.yaml
+++ b/charts/tooljet/values.yaml
@@ -2,7 +2,7 @@ apps:
   tooljet:
     service:
       type: ClusterIP
-      host: "http://localhost"
+      host: "http://tooljet.localhost"
     deployment:
       image:
         repository: tooljet/tooljet-ce
@@ -27,6 +27,14 @@ apps:
         lockbox_key: "0123456789ABCDEF"
         secret_key_base: "0123456789ABCDEF"
 
+ingress:
+  enabled: true
+  hostname: tooljet.localhost
+  ingressClassName: 'nginx'
+  kubernetes.io/ingress.class: "nginx"
+  annotations:
+    {}
+  tls: []
 # https://artifacthub.io/packages/helm/bitnami/postgresql#global-parameters
 postgresql:
   enabled: true
@@ -99,5 +107,3 @@ service:
   type: ClusterIP
   port: 3000
   annotations: {}
-
-  


### PR DESCRIPTION
## Motivation:

The existing Tooljet Helm Chart lacks support for Kubernetes ingress, hindering users who seek to manage access to HTTP and HTTPS routes from outside their cluster to services within the cluster. The implementation of an ingress setup enhances the usability and flexibility of the deployment within Kubernetes environments, enabling URL routing and load balancing functionalities.

## Proposed Changes:

**1. Ingress Configuration:**

Introduces ingress.yaml to define the ingress resource, aligning with common routing and load balancing practices.

**2. Values Customization:**

Modifies values.yaml to accommodate new ingress settings, ensuring compatibility and extending configurability to users.

**3. Helper Functionality:**

Implements a helper file to simplify the naming convention and variable reference, enhancing code maintainability and readability.

**4. Service Name Adjustment:**

Refactors the service name of the app to ensure consistency and clear reference within the Kubernetes environment.

**5. Chart Version Update:**

Upgrades the chart version to 2.6.1 to reflect the new changes and ensure versioning adherence.

## Tasks:

- [x]  Add ingress.yaml for ingress configuration.
- [x]  Update values.yaml to ensure compatibility with new ingress setup.
- [x]  Introduce helper file for simplified variable naming.
- [x]  Modify the service name of the app for coherent referencing.
- [x]  Bump the chart version to 2.6.1.

**Testing:**

To validate the effectiveness and correctness of the proposed modifications, consider performing the following tests:

- [x] Deploy the helm chart with the new ingress configuration and validate routing and accessibility.
- [x] Validate compatibility and proper referencing with updated values.yaml and service name across different deployment scenarios.

- [x] AWS EKS 
- [x] GCP GKE
- [x] Azure AKS