### PR TITLE
SMTP Environment variables for deployment

### DIFF
--- a/charts/tooljet/templates/deployment.yaml
+++ b/charts/tooljet/templates/deployment.yaml
@@ -93,6 +93,20 @@ spec:
               value: {{ .Values.redis_pod.REDIS_USER }}
             - name: REDIS_PASSWORD
               value: {{ .Values.redis_pod.REDIS_PASSWORD }}
+            - name: DEFAULT_FROM_EMAIL
+              value: {{ .Values.env.DEFAULT_FROM_EMAIL }}
+            {{- if .Values.env.SMTP_USERNAME }}
+            - name: SMTP_USERNAME
+              value: {{ .Values.env.SMTP_USERNAME }}
+            {{- end }}
+            {{- if .Values.env.SMTP_PASSWORD }}
+            - name: SMTP_PASSWORD
+              value: {{ .Values.env.SMTP_PASSWORD }}
+            {{- end }}
+            - name: SMTP_DOMAIN
+              value: {{ .Values.env.SMTP_DOMAIN }}
+            - name: SMTP_PORT
+              value: {{ .Values.env.SMTP_PORT | | default "25" | quote }}
           envFrom:
             - secretRef:
                 name: {{ .Values.apps.tooljet.secret.name }}

--- a/charts/tooljet/templates/deployment.yaml
+++ b/charts/tooljet/templates/deployment.yaml
@@ -93,8 +93,10 @@ spec:
               value: {{ .Values.redis_pod.REDIS_USER }}
             - name: REDIS_PASSWORD
               value: {{ .Values.redis_pod.REDIS_PASSWORD }}
+            {{- if  .Values.env.DEFAULT_FROM_EMAIL }}
             - name: DEFAULT_FROM_EMAIL
               value: {{ .Values.env.DEFAULT_FROM_EMAIL }}
+            {{- end }}
             {{- if .Values.env.SMTP_USERNAME }}
             - name: SMTP_USERNAME
               value: {{ .Values.env.SMTP_USERNAME }}
@@ -103,10 +105,14 @@ spec:
             - name: SMTP_PASSWORD
               value: {{ .Values.env.SMTP_PASSWORD }}
             {{- end }}
+            {{- if .Values.env.SMTP_DOMAIN }}
             - name: SMTP_DOMAIN
               value: {{ .Values.env.SMTP_DOMAIN }}
+            {{- end }}
+            {{- if .Values.env.SMTP_PORT }}
             - name: SMTP_PORT
-              value: {{ .Values.env.SMTP_PORT | | default "25" | quote }}
+              value: {{ .Values.env.SMTP_PORT }}
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ .Values.apps.tooljet.secret.name }}


### PR DESCRIPTION
This Pull Request introduces enhancements to the ToolJet Helm chart by adding support for configurable SMTP environment variables. These changes enable users to customize their SMTP settings directly through the Helm chart values, making it more flexible and suited for various deployment scenarios.

Changes made:
- Added Helm chart support for setting the DEFAULT_FROM_EMAIL environment variable. This allows users to specify the default sender email address for outgoing emails.
- Included SMTP_USERNAME and SMTP_PASSWORD environment variables, enabling the configuration of authentication credentials for the SMTP server.
- Added SMTP_DOMAIN and SMTP_PORT environment variables to define the domain and port of the SMTP server, respectively.

These additions provide users with the flexibility to configure their SMTP settings according to their specific needs, enhancing the usability of the ToolJet application in different environments. This PR ensures that these settings are optional and can be defined as needed by the user.

Reference: https://docs.tooljet.com/docs/setup/env-vars/#smtp-configuration--optional-

Looking forward to your feedback and suggestions for further improvements.
