### PR TITLE
Update values.yaml

### DIFF
--- a/charts/tooljet/values.yaml
+++ b/charts/tooljet/values.yaml
@@ -102,7 +102,7 @@ autoscaling:
 
 image:
   repository: postgrest/postgrest
-  tag: v10.1.1.20221215
+  tag: v10.1.1
   pullPolicy: IfNotPresent
 
 postgrest:


### PR DESCRIPTION
v10.1.1.20221215 doesn't exist in dockerhub.

```
docker pull docker.io/postgrest/postgrest:v10.1.1.20221215
Error response from daemon: manifest for postgrest/postgrest:v10.1.1.20221215 not found: manifest unknown: manifest unknown
```
v10.1.1 does.