### PR TITLE
Prevent duplicate labels

### DIFF
--- a/charts/tooljet/templates/_helpers.tpl
+++ b/charts/tooljet/templates/_helpers.tpl
@@ -35,12 +35,12 @@ Common labels
 */}}
 {{- define "tooljet.labels" -}}
 helm.sh/chart: {{ include "tooljet.chart" . }}
-{{ include "tooljet.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
 
 {{/*
 Selector labels

--- a/charts/tooljet/templates/deployment-pgrst.yml
+++ b/charts/tooljet/templates/deployment-pgrst.yml
@@ -4,24 +4,22 @@ metadata:
   name: {{ include "tooljet.fullname" . }}-postgrest
   labels:
     {{- include "tooljet.labels" . | nindent 4 }}
-    app.kubernetes.io/component: tooljet-postgrest
-    app.kubernetes.io/instance: tooljet-postgrest
-    app.kubernetes.io/name: tooljet-postgrest
+    app.kubernetes.io/component: {{ .Release.Name }}-postgrest
+    app.kubernetes.io/instance: {{ .Release.Name }}-postgrest
+    app.kubernetes.io/name: {{ .Release.Name }}-postgrest
 spec:
   replicas: {{ .Values.postgrest.replicaCount | default 1 }}
   selector:
     matchLabels:
-      {{- include "tooljet.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: tooljet-postgrest
-      app.kubernetes.io/instance: tooljet-postgrest
-      app.kubernetes.io/name: tooljet-postgrest
+      app.kubernetes.io/component: {{ .Release.Name }}-postgrest
+      app.kubernetes.io/instance: {{ .Release.Name }}-postgrest
+      app.kubernetes.io/name: {{ .Release.Name }}-postgrest
   template:
     metadata:
       labels:
-        {{- include "tooljet.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: tooljet-postgrest
-        app.kubernetes.io/instance: tooljet-postgrest
-        app.kubernetes.io/name: tooljet-postgrest
+        app.kubernetes.io/component: {{ .Release.Name }}-postgrest
+        app.kubernetes.io/instance: {{ .Release.Name }}-postgrest
+        app.kubernetes.io/name: {{ .Release.Name }}-postgrest
     spec:
       containers:
         - name: postgrest

--- a/charts/tooljet/templates/deployment.yaml
+++ b/charts/tooljet/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "tooljet.fullname" . }}
   labels:
     {{- include "tooljet.labels" . | nindent 4 }}
+    {{- include "tooljet.selectorLabels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.apps.tooljet.replicaCount }}

--- a/charts/tooljet/templates/ingress.yml
+++ b/charts/tooljet/templates/ingress.yml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "tooljet.fullname" . }}
   labels:
     {{- include "tooljet.labels" . | nindent 4 }}
+    {{- include "tooljet.selectorLabels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/tooljet/templates/secret.yaml
+++ b/charts/tooljet/templates/secret.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ .Values.apps.tooljet.secret.name }}
   labels:
     {{- include "tooljet.labels" . | nindent 4 }}
+    {{- include "tooljet.selectorLabels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if not .Values.external_postgresql.enabled }}

--- a/charts/tooljet/templates/service-pgrst.yml
+++ b/charts/tooljet/templates/service-pgrst.yml
@@ -4,15 +4,14 @@ metadata:
   name: {{ include "tooljet.fullname" . }}-postgrest
   labels:
     {{- include "tooljet.labels" . | nindent 4 }}
-    app.kubernetes.io/component: tooljet-postgrest
-    app.kubernetes.io/instance: tooljet-postgrest
-    app.kubernetes.io/name: tooljet-postgrest
+    app.kubernetes.io/component: {{ .Release.Name }}-postgrest
+    app.kubernetes.io/instance: {{ .Release.Name }}-postgrest
+    app.kubernetes.io/name: {{ .Release.Name }}-postgrest
 spec:
   selector:
-    {{- include "tooljet.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: tooljet-postgrest
-    app.kubernetes.io/instance: tooljet-postgrest
-    app.kubernetes.io/name: tooljet-postgrest
+    app.kubernetes.io/component: {{ .Release.Name }}-postgrest
+    app.kubernetes.io/instance: {{ .Release.Name }}-postgrest
+    app.kubernetes.io/name: {{ .Release.Name }}-postgrest
   type: {{ .Values.postgrest.service.type }}
   ports:
     - name: http

--- a/charts/tooljet/templates/service.yaml
+++ b/charts/tooljet/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "tooljet.fullname" . }}
   labels:
     {{- include "tooljet.labels" . | nindent 4 }}
+    {{- include "tooljet.selectorLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.apps.tooljet.service.type }}
   ports:


### PR DESCRIPTION
Addresses https://github.com/ToolJet/helm-charts/issues/45

There are 2 real changes here and I am happy to amend based on feedback

1.  Changing the hardcoded `tooljet-postgrest` labels to rather rely on the release names instead so that multiple helm releases could be deployed into the same namespace
2. Removing the selectorLabels from common labels as they do not appear to be common and are actually specific to the tooljet only portion of the system, not the "external" systems like postgrest. I've readded the selector labels to where ever I found the common labels to be used explicitly to prevent regression however

If anyone adds testing to this repo I'm happy to update to show that the labels should be as expected