### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This setup comes with an included PostgreSQL server out of the box which is enab
 
 ### From Helm repo
 ```bash
-helm repo add tooljet https://github.com/ToolJet/helm-charts.git
+helm repo add tooljet https://tooljet.github.io/helm-charts
 helm install tooljet tooljet/tooljet
 ```
 


### PR DESCRIPTION
## Reason for the change

Mentioned Helm Repo in README page is not correct. Correct one should be `https://tooljet.github.io/helm-charts`