### PR TITLE
Remove duplicate labels from postgrest deployment and service

### DIFF
--- a/charts/tooljet/templates/_helpers.tpl
+++ b/charts/tooljet/templates/_helpers.tpl
@@ -51,6 +51,27 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Postgrest labels
+*/}}
+{{- define "tooljet-postgrest.labels" -}}
+helm.sh/chart: {{ include "tooljet.chart" . }}
+{{ include "tooljet-postgrest.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Postgrest Selector labels
+*/}}
+{{- define "tooljet-postgrest.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tooljet.name" . }}-postgrest
+app.kubernetes.io/component: {{ include "tooljet.name" . }}-postgrest
+app.kubernetes.io/instance: {{ .Release.Name }}-postgrest
+{{- end }}
+
+{{/*
 Create a default fully qualified postgresql name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/tooljet/templates/deployment-pgrst.yml
+++ b/charts/tooljet/templates/deployment-pgrst.yml
@@ -4,24 +4,15 @@ metadata:
   name: {{ include "tooljet.fullname" . }}-postgrest
   labels:
     {{- include "tooljet.labels" . | nindent 4 }}
-    app.kubernetes.io/component: tooljet-postgrest
-    app.kubernetes.io/instance: tooljet-postgrest
-    app.kubernetes.io/name: tooljet-postgrest
 spec:
   replicas: {{ .Values.postgrest.replicaCount | default 1 }}
   selector:
     matchLabels:
-      {{- include "tooljet.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: tooljet-postgrest
-      app.kubernetes.io/instance: tooljet-postgrest
-      app.kubernetes.io/name: tooljet-postgrest
+      {{- include "tooljet-postgrest.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "tooljet.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: tooljet-postgrest
-        app.kubernetes.io/instance: tooljet-postgrest
-        app.kubernetes.io/name: tooljet-postgrest
+        {{- include "tooljet-postgrest.selectorLabels" . | nindent 8 }}
     spec:
       containers:
         - name: postgrest

--- a/charts/tooljet/templates/service-pgrst.yml
+++ b/charts/tooljet/templates/service-pgrst.yml
@@ -3,16 +3,10 @@ kind: Service
 metadata:
   name: {{ include "tooljet.fullname" . }}-postgrest
   labels:
-    {{- include "tooljet.labels" . | nindent 4 }}
-    app.kubernetes.io/component: tooljet-postgrest
-    app.kubernetes.io/instance: tooljet-postgrest
-    app.kubernetes.io/name: tooljet-postgrest
+    {{- include "tooljet-postgrest.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "tooljet.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: tooljet-postgrest
-    app.kubernetes.io/instance: tooljet-postgrest
-    app.kubernetes.io/name: tooljet-postgrest
+    {{- include "tooljet-postgrest.selectorLabels" . | nindent 4 }}
   type: {{ .Values.postgrest.service.type }}
   ports:
     - name: http


### PR DESCRIPTION
This PR removes conflicting and duplicated labels from postgrest `Deployment` and `Service` resources which were preventing chart reconciliation with [Flux](https://fluxcd.io/flux/components/helm/helmreleases/)