### PR TITLE
feat: add support for configurable service account for tooljet app

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/charts/tooljet/templates/_helpers.tpl
+++ b/charts/tooljet/templates/_helpers.tpl
@@ -148,3 +148,14 @@ Return the appropriate apiVersion for autoscaling.
 {{- print "autoscaling/v2beta2" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the service account name
+*/}}
+{{- define "tooljet.serviceAccountName" -}}
+{{- if .Values.apps.tooljet.serviceAccount.name -}}
+{{- .Values.apps.tooljet.serviceAccount.name -}}
+{{- else -}}
+{{- include "tooljet.fullname" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/tooljet/templates/deployment.yaml
+++ b/charts/tooljet/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       labels:
         {{- include "tooljet.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.apps.tooljet.serviceAccount.create }}
+      serviceAccountName: {{ include "tooljet.serviceAccountName" . }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.apps.tooljet.deployment.image.repository }}:{{ .Values.apps.tooljet.deployment.image.tag }}"

--- a/charts/tooljet/templates/serviceaccount.yml
+++ b/charts/tooljet/templates/serviceaccount.yml
@@ -1,0 +1,12 @@
+{{- if .Values.apps.tooljet.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tooljet.serviceAccountName" . }}
+  labels:
+    {{- include "tooljet.labels" . | nindent 4 }}
+  {{- if .Values.apps.tooljet.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.apps.tooljet.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tooljet/values.yaml
+++ b/charts/tooljet/values.yaml
@@ -30,6 +30,10 @@ apps:
       port: 80
       targetPort: 3000
       type: ClusterIP
+    serviceAccount:
+      create: false
+      name: ""
+      annotations: {}
 
 postgresql:
   enabled: true


### PR DESCRIPTION
## Description:

This PR introduces support for customizing the Kubernetes ServiceAccount used by the ToolJet deployment. This enables more secure and flexible integration with cloud-native identity management systems, such as IAM Roles for Service Accounts (IRSA) in AWS EKS.

## Key Features:

- `serviceAccount.create`: Enables or disables automatic creation of a ServiceAccount
- `serviceAccount.name`: Optionally specify a custom ServiceAccount name
- `serviceAccount.annotations`: Support for adding annotations (e.g., eks.amazonaws.com/role-arn)

## Helm Values Example:

```
serviceAccount:
  create: true
  name: tooljet-irsa
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/ToolJetRole
```

## Files Updated:

- values.yaml — adds new service account configuration options
- templates/serviceaccount.yaml — creates the ServiceAccount resource conditionally
- templates/deployment.yaml — injects serviceAccountName into the pod spec
- templates/_helpers.tpl — helper to resolve the final service account name

## Backward Compatibility

This change is fully backward compatible. If serviceAccount.create is false and no name is provided, default Kubernetes behavior will apply.